### PR TITLE
Fix #15: add holiday details

### DIFF
--- a/api/src/cookiebreaks/api/routers/breaks.py
+++ b/api/src/cookiebreaks/api/routers/breaks.py
@@ -9,6 +9,7 @@ from cookiebreaks.core.database import (
     get_break_objects,
     insert_host,
     reimburse_and_mask_host,
+    set_holiday,
 )
 from cookiebreaks.api.routers.users import get_current_user, is_admin
 from cookiebreaks.api.routers.utils import get_breaks
@@ -76,3 +77,15 @@ async def reimburse_host(
 ):
     reimbursed_break = reimburse_and_mask_host(break_id, cost)
     return break_internal_to_external(reimbursed_break, current_user)
+
+
+@router.post(
+    "/holiday",
+    response_model=Break,
+    summary="Record the reimbursement of someone who hosted a cookie break",
+)
+async def post_holiday(
+    current_user: Annotated[User, Depends(is_admin)], break_id: int, reason: str
+):
+    changed_break = set_holiday(break_id, reason)
+    return break_internal_to_external(changed_break, current_user)

--- a/api/src/cookiebreaks/api/routers/utils.py
+++ b/api/src/cookiebreaks/api/routers/utils.py
@@ -17,7 +17,7 @@ class BreakExternal:
     id: int
     break_time: datetime
     location: str
-    holiday: bool
+    holiday: Optional[str]
     host: Optional[str]
     break_announced: Optional[datetime]
     cost: Optional[float]

--- a/api/src/cookiebreaks/core/structs.py
+++ b/api/src/cookiebreaks/core/structs.py
@@ -20,7 +20,7 @@ class Break:
     id: int
     break_time: Arrow
     location: str
-    holiday: bool
+    holiday: Optional[str]
     host: Optional[str] = None
     break_announced: Optional[Arrow] = None
     cost: Optional[float] = None

--- a/api/src/cookiebreaks/tasks/holiday.py
+++ b/api/src/cookiebreaks/tasks/holiday.py
@@ -9,23 +9,11 @@ def holiday():
         print("No choice made, exiting")
         exit(0)
     else:
-        if chosen_break.holiday:
-            choice = input(
-                f"Make {chosen_break.get_break_datetime()} a non-holiday? (y/N) "
-            )
-            if choice == "y":
-                holiday = False
-            else:
-                exit(0)
+        reason = input(f"Reason for holiday on {chosen_break.get_break_datetime()}? ")
+        if reason == "":
+            set_holiday(chosen_break.id)
         else:
-            choice = input(
-                f"Make {chosen_break.get_break_datetime()} a holiday? (y/N) "
-            )
-            if choice == "y":
-                holiday = True
-            else:
-                exit(0)
-        set_holiday(chosen_break.id, holiday)
+            set_holiday(chosen_break.id, reason)
 
 
 if __name__ == "__main__":

--- a/client/src/app/api.ts
+++ b/client/src/app/api.ts
@@ -10,6 +10,7 @@ const responseToBreak = (b: any) => ({
     host: b.host,
     datetime: new Date(b.break_time),
     location: b.location,
+    holiday: b.holiday,
     cost: b.cost,
     announced: dateOrUndefined(b.break_announced),
     reimbursed: dateOrUndefined(b.host_reimbursed),

--- a/client/src/app/breaks.tsx
+++ b/client/src/app/breaks.tsx
@@ -59,7 +59,9 @@ const BreakIcons = (props: {
                 props.user?.admin ? "w-full desktop:w-1/6" : ""
             } items-center justify-center`}
         >
-            {isLoadingCard ? (
+            {props.cb.holiday ? (
+                ""
+            ) : isLoadingCard ? (
                 <Loader size={10} />
             ) : props.user && props.user.admin ? (
                 <>
@@ -146,23 +148,27 @@ const BreakCard = (props: {
     updateBreaks: (breaks: CookieBreak[]) => void
 }) => {
     let pastBreak = dateInPast(props.cb.datetime)
-    let hostText =
-        props.cb.host === null
-            ? pastBreak
-                ? "Host reimbursed"
-                : "Host required"
-            : props.cb.host
+    let contentText = props.cb.holiday
+        ? props.cb.holiday
+        : props.cb.host === null
+        ? pastBreak
+            ? "Host reimbursed"
+            : "Host required"
+        : props.cb.host
+    let cardColour = props.cb.holiday ? "bg-gray-300" : "bg-white"
+    let contentTextStyle =
+        props.cb.holiday || props.cb.host === null ? "italic text-sm" : "bold"
     return (
-        <div className="flex w-3/4 desktop:w-content tablet:w-tabletContent flex-wrap border-4 m-5 p-1 px-5 mx-auto items-center justify-center">
+        <div
+            className={`flex w-3/4 desktop:w-content tablet:w-tabletContent flex-wrap border-4 m-5 p-1 px-5 mx-auto items-center justify-center ${cardColour}`}
+        >
             <div className="w-full tablet:w-1/2 my-2 desktop:mx-0 desktop:w-1/3 text-center font-bold">
                 {getCookieBreakDate(props.cb)}, {getCookieBreakTime(props.cb)}
             </div>
             <div
-                className={`flex-1 my-2 desktop:mx-0 text-center px-5 ${
-                    props.cb.host === null ? "italic text-sm" : "bold"
-                }`}
+                className={`flex-1 my-2 desktop:mx-0 text-center px-5 ${contentTextStyle}`}
             >
-                {hostText}
+                {contentText}
             </div>
             <BreakIcons
                 cb={props.cb}

--- a/client/src/app/structs.ts
+++ b/client/src/app/structs.ts
@@ -10,6 +10,7 @@ export interface CookieBreak {
     id: number
     host: string
     location: string
+    holiday?: string
     cost?: number
     datetime: Date
     announced?: Date


### PR DESCRIPTION
When a break is a holiday, it is greyed out and the holiday details are displayed instead of 'host required'. Holidayed breaks no longer show the admin control panel.