### PR TITLE
Add host selection capabilities to admin view

### DIFF
--- a/api/src/cookiebreaks/core/database.py
+++ b/api/src/cookiebreaks/core/database.py
@@ -64,16 +64,19 @@ def insert_breaks(breaks: list[tuple[Arrow, str]]) -> None:
     disconnect(conn, cur)
 
 
-def insert_host(break_host: str, break_id: int) -> None:
+def insert_host(break_host: str | None, break_id: int) -> None:
     (conn, cur) = connect()
     statement = f"""
         UPDATE break
         SET break_host = %(host)s
         WHERE break_id = %(id)s
+        RETURNING *
     """
     cur.execute(statement, {"host": break_host, "id": break_id})
+    row = cur.fetchall()[0]
     conn.commit()
     disconnect(conn, cur)
+    return row_to_break(row)
 
 
 def reimburse_and_mask_host(break_id: int, cost: float) -> Break:

--- a/client/src/app/api.ts
+++ b/client/src/app/api.ts
@@ -115,3 +115,50 @@ export const reimburseBreak = async (
     updateBreaks([responseToBreak(responseData)])
     setLoadingCard(false)
 }
+
+export const setHost = async (
+    user: User,
+    id: number,
+    host: string,
+    updateBreaks: (breaks: CookieBreak[]) => void,
+    setLoadingCard: Dispatch<SetStateAction<boolean>>
+) => {
+    let actualHost = host === "" ? undefined : host
+    let endpoint = `/api/breaks/host`
+    let config = {
+        params: {
+            break_id: id,
+            host_name: actualHost,
+        },
+        headers: headers(user.token),
+    }
+    setLoadingCard(true)
+    let response = await axios.post(endpoint, null, config)
+    let responseData = response.data
+    console.log(responseData)
+    updateBreaks([responseToBreak(responseData)])
+    setLoadingCard(false)
+}
+
+export const setHoliday = async (
+    user: User,
+    id: number,
+    reason: string,
+    updateBreaks: (breaks: CookieBreak[]) => void,
+    setLoadingCard: Dispatch<SetStateAction<boolean>>
+) => {
+    let endpoint = `/api/breaks/holiday`
+    let config = {
+        params: {
+            break_id: id,
+            reason,
+        },
+        headers: headers(user.token),
+    }
+    setLoadingCard(true)
+    let response = await axios.post(endpoint, null, config)
+    let responseData = response.data
+    console.log(responseData)
+    updateBreaks([responseToBreak(responseData)])
+    setLoadingCard(false)
+}

--- a/client/src/app/breaks.tsx
+++ b/client/src/app/breaks.tsx
@@ -11,6 +11,29 @@ import {
 import Image from "next/image"
 import Loader from "./loader"
 
+const SmallIcon = (props: {
+    icon: string
+    styles: string
+    title: string
+    alt: string
+    onClick?: (e: React.MouseEvent<HTMLDivElement>) => void
+}) => {
+    let style = `${props.styles}  ${
+        props.onClick ? " cursor-pointer hover:bg-gray-300 rounded-full" : ""
+    }`
+    return (
+        <Image
+            className={style}
+            onClick={props.onClick}
+            width={30}
+            height={30}
+            src={`/images/icons/${props.icon}.svg`}
+            title={props.title}
+            alt={props.title}
+        />
+    )
+}
+
 const BreakIcon = (props: {
     icon: string
     doneText: string
@@ -22,26 +45,19 @@ const BreakIcon = (props: {
     let titleText = !props.datetime
         ? props.waitingText
         : `${props.doneText} on ${getDatetimeText(props.datetime)}`
-    let opacity = !props.datetime ? 0.25 : 1
+    let opacity = !props.datetime ? "25" : "100"
     const onClickIcon = (e: React.MouseEvent<HTMLDivElement>) => {
         if (props.clickable && props.onClick) {
             props.onClick()
         }
     }
     return (
-        <Image
-            className={`my-2 desktop:m-0 ${
-                props.clickable
-                    ? "cursor-pointer hover:bg-gray-300 rounded-full bg-opacity-30 hover:"
-                    : ""
-            }`}
+        <SmallIcon
+            styles={`my-2 desktop:m-0 opacity-${opacity}`}
             onClick={onClickIcon}
-            width={30}
-            height={30}
-            src={`/images/icons/${props.icon}.svg`}
+            icon={props.icon}
             title={titleText}
             alt={titleText}
-            style={{ opacity: opacity }}
         />
     )
 }

--- a/client/src/app/breaks.tsx
+++ b/client/src/app/breaks.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react"
-import { announceBreak, reimburseBreak } from "./api"
+import React, { useRef, useState } from "react"
+import { announceBreak, reimburseBreak, setHoliday, setHost } from "./api"
 import {
     getDatetimeText,
     User,
@@ -163,17 +163,67 @@ const BreakCard = (props: {
     cb: CookieBreak
     updateBreaks: (breaks: CookieBreak[]) => void
 }) => {
-    let pastBreak = dateInPast(props.cb.datetime)
-    let contentText = props.cb.holiday
+    let hasPassed = dateInPast(props.cb.datetime)
+    let isHoliday = props.cb.holiday !== null
+    let hasHost = props.cb.host !== null
+    let isAdmin = props.user?.admin
+
+    const [contentLoading, setContentLoading] = useState(false)
+    const [editingText, setEditingText] = useState(false)
+    const contentTextRef = useRef<HTMLInputElement | null>(null)
+
+    let contentText = isHoliday
         ? props.cb.holiday
-        : props.cb.host === null
-        ? pastBreak
+        : !hasHost
+        ? hasPassed
             ? "Host reimbursed"
             : "Host required"
         : props.cb.host
-    let cardColour = props.cb.holiday ? "bg-gray-300" : "bg-white"
+    let cardColour = isHoliday ? "bg-gray-300" : "bg-white"
+
     let contentTextStyle =
-        props.cb.holiday || props.cb.host === null ? "text-sm" : "bold"
+        isHoliday || !hasHost ? "text-sm" : editingText ? "" : "font-bold"
+    let clickable = isAdmin && !dateInPast(props.cb.datetime)
+    let clickableStyle = clickable
+        ? "cursor-pointer hover:bg-gray-300/50 rounded-md"
+        : ""
+
+    const onClickText = (e: React.MouseEvent<HTMLDivElement>) => {
+        if (clickable) {
+            setEditingText(true)
+        }
+    }
+    const discardContentText = () => {
+        setEditingText(false)
+    }
+    const submitContentText = () => {
+        if (props.user && contentTextRef.current) {
+            let request = isHoliday ? setHoliday : setHost
+            request(
+                props.user,
+                props.cb.id,
+                contentTextRef.current.value,
+                props.updateBreaks,
+                setContentLoading
+            )
+        }
+        setEditingText(false)
+    }
+    const onClickCloseText = (e: React.MouseEvent<HTMLDivElement>) => {
+        e.stopPropagation()
+        discardContentText()
+    }
+    const onClickConfirmText = (e: React.MouseEvent<HTMLDivElement>) => {
+        e.stopPropagation()
+        submitContentText()
+    }
+    const onKeyDownContentText = (e: React.KeyboardEvent<HTMLInputElement>) => {
+        if (e.key === "Enter") {
+            submitContentText()
+        } else if (e.key === "Escape") {
+            discardContentText()
+        }
+    }
     return (
         <div
             className={`flex w-3/4 desktop:w-content tablet:w-tabletContent flex-wrap border-4 m-5 p-1 px-5 mx-auto items-center justify-center ${cardColour}`}
@@ -182,15 +232,49 @@ const BreakCard = (props: {
                 {getCookieBreakDate(props.cb)}, {getCookieBreakTime(props.cb)}
             </div>
             <div
-                className={`flex-1 my-2 desktop:mx-0 text-center px-5 ${contentTextStyle}`}
+                className={`flex-1 desktop:mx-0 text-center px-5`}
+                onClick={onClickText}
             >
-                {contentText}
+                {contentLoading ? (
+                    <Loader size={10} />
+                ) : !editingText ? (
+                    <span
+                        className={`p-2 ${clickableStyle} ${contentTextStyle}`}
+                    >
+                        {contentText}
+                    </span>
+                ) : (
+                    <div className="flex flex-row">
+                        <SmallIcon
+                            icon="cross"
+                            styles=""
+                            title="Close"
+                            alt="cross"
+                            onClick={onClickCloseText}
+                        />
+                        <input
+                            ref={contentTextRef}
+                            autoFocus
+                            type="text"
+                            className="w-full text-center mx-2"
+                            placeholder="Host required"
+                            onKeyDown={onKeyDownContentText}
+                        />
+                        <SmallIcon
+                            icon="tick"
+                            styles=""
+                            title="Confirm"
+                            alt="tick"
+                            onClick={onClickConfirmText}
+                        />
+                    </div>
+                )}
             </div>
             <BreakIcons
                 cb={props.cb}
                 updateBreaks={props.updateBreaks}
                 user={props.user}
-                pastBreak={pastBreak}
+                pastBreak={hasPassed}
             />
         </div>
     )


### PR DESCRIPTION
Admins can now set the host of a cookie break or the reason for a holiday by clicking on the text on the card.