### PR TITLE
Remove console.log from client side scripts

### DIFF
--- a/client/src/app/api.ts
+++ b/client/src/app/api.ts
@@ -144,7 +144,6 @@ export const setHost = async (
     setLoadingCard(true)
     let response = await axios.post(endpoint, null, config)
     let responseData = response.data
-    console.log(responseData)
     updateBreaks([responseToBreak(responseData)], [])
     setLoadingCard(false)
 }
@@ -170,7 +169,6 @@ export const setHoliday = async (
     setLoadingCard(true)
     let response = await axios.post(endpoint, null, config)
     let responseData = response.data
-    console.log(responseData)
     updateBreaks([responseToBreak(responseData)], [])
     setLoadingCard(false)
 }

--- a/client/src/app/structs.ts
+++ b/client/src/app/structs.ts
@@ -59,8 +59,6 @@ export const getCookieBreakTime = (cb: CookieBreak) =>
 export const getFutureBreaks = (cbs: CookieBreak[]) => {
     let date = new Date()
     date.setHours(0, 0, 0, 0)
-    console.log(cbs)
-    console.log(date)
     return cbs.filter((cb) => cb.datetime.getTime() > date.getTime())
 }
 export const getOutstandingBreaks = (cbs: CookieBreak[]) =>


### PR DESCRIPTION
Removes all the client side console logging.
Fixes #38 
Untested because my Ubuntu is now dead :(