### PR TITLE
Fix #36: issues with placeholder text on host/holiday selection

### DIFF
--- a/client/src/app/breaks.tsx
+++ b/client/src/app/breaks.tsx
@@ -289,7 +289,7 @@ const BreakCard = (props: {
                             ref={contentTextRef}
                             autoFocus
                             type="text"
-                            className="w-full text-center mx-2"
+                            className="w-full text-center mx-2 text-sm"
                             placeholder={placeholderText}
                             onKeyDown={onKeyDownContentText}
                         />

--- a/client/src/app/breaks.tsx
+++ b/client/src/app/breaks.tsx
@@ -198,7 +198,7 @@ const BreakCard = (props: {
     let clickableStyle = clickable
         ? "cursor-pointer hover:bg-gray-300/50 rounded-md"
         : ""
-
+    let placeholderText = isHoliday ? "Holiday" : "Host required"
     const onClickText = (e: React.MouseEvent<HTMLDivElement>) => {
         if (clickable) {
             setEditingText(true)
@@ -290,7 +290,7 @@ const BreakCard = (props: {
                             autoFocus
                             type="text"
                             className="w-full text-center mx-2"
-                            placeholder="Host required"
+                            placeholder={placeholderText}
                             onKeyDown={onKeyDownContentText}
                         />
                         <SmallIcon


### PR DESCRIPTION
Two changes

* Make placeholder text say 'holiday' rather than 'host required' where relevant
* Make size of placeholder/entered text a little smaller to match other elements