### PR TITLE
[fix] Stop flicker of outstanding breaks when updating

### DIFF
--- a/client/src/app/breaks.tsx
+++ b/client/src/app/breaks.tsx
@@ -271,9 +271,6 @@ export const BreakCards = (props: {
     isLoadingBreaks: boolean
     reverseBreaks: boolean
 }) => {
-    const breakList = props.reverseBreaks
-        ? props.breaks.reverse()
-        : props.breaks
     return (
         <>
             <div className="text-xl font-bold text-center m-5">
@@ -284,10 +281,10 @@ export const BreakCards = (props: {
                     <Loader size={10} />
                 </div>
             ) : (
-                breakList.map((cb) => (
+                props.breaks.map((cb) => (
                     <BreakCard
                         user={props.user}
-                        key={`${cb.id}`}
+                        key={cb.id}
                         cb={cb}
                         updateBreaks={props.updateBreaks}
                     />

--- a/client/src/app/page.tsx
+++ b/client/src/app/page.tsx
@@ -33,7 +33,7 @@ const Home = () => {
     }, [])
     useEffect(() => {
         setUpcomingBreaks(getFutureBreaks(breaks))
-        setOutstandingBreaks(getOutstandingBreaks(breaks))
+        setOutstandingBreaks(getOutstandingBreaks(breaks).reverse())
     }, [breaks])
     const updateBreaks = (
         newBreaks: CookieBreak[],


### PR DESCRIPTION
Fixes bug introduced by @brunorochapaiva where outstanding breaks would flicker into the unreversed version for some reason